### PR TITLE
Build against otel-collector version 0.111.0

### DIFF
--- a/metricsasattributesprocessor/factory.go
+++ b/metricsasattributesprocessor/factory.go
@@ -53,7 +53,7 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createMetricsProcessor(ctx context.Context, set processor.CreateSettings, cfg component.Config, nextConsumer consumer.Metrics) (processor.Metrics, error) {
+func createMetricsProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Metrics) (processor.Metrics, error) {
 	p, err := newMetricsProcessor(set, cfg.(*Config))
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func createMetricsProcessor(ctx context.Context, set processor.CreateSettings, c
 		processorhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}))
 }
 
-func createTracesProcessor(ctx context.Context, set processor.CreateSettings, cfg component.Config, nextConsumer consumer.Traces) (processor.Traces, error) {
+func createTracesProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Traces) (processor.Traces, error) {
 	p, err := newTracesProcessor(set, cfg.(*Config))
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func createTracesProcessor(ctx context.Context, set processor.CreateSettings, cf
 		processorhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}))
 }
 
-func createLogsProcessor(ctx context.Context, set processor.CreateSettings, cfg component.Config, nextConsumer consumer.Logs) (processor.Logs, error) {
+func createLogsProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Logs) (processor.Logs, error) {
 	p, err := newLogsProcessor(set, cfg.(*Config))
 	if err != nil {
 		return nil, err

--- a/metricsasattributesprocessor/logs.go
+++ b/metricsasattributesprocessor/logs.go
@@ -2,6 +2,7 @@ package metricsasattributesprocessor
 
 import (
 	"context"
+
 	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/cache"
 	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/common"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -18,7 +19,7 @@ type logsProcessor struct {
 	logger *zap.Logger
 }
 
-func newLogsProcessor(set processor.CreateSettings, cfg *Config) (*logsProcessor, error) {
+func newLogsProcessor(set processor.Settings, cfg *Config) (*logsProcessor, error) {
 	p := &logsProcessor{
 		config: cfg,
 		cache:  cache.GetCache(set.ID.String(), cfg.CacheTtl, cfg.MetricGroups, set.Logger),

--- a/metricsasattributesprocessor/metrics.go
+++ b/metricsasattributesprocessor/metrics.go
@@ -2,6 +2,7 @@ package metricsasattributesprocessor
 
 import (
 	"context"
+
 	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/cache"
 	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/common"
 	"github.com/vodkaslime/wildcard"
@@ -18,7 +19,7 @@ type metricsProcessor struct {
 	logger          *zap.Logger
 }
 
-func newMetricsProcessor(set processor.CreateSettings, cfg *Config) (*metricsProcessor, error) {
+func newMetricsProcessor(set processor.Settings, cfg *Config) (*metricsProcessor, error) {
 	p := &metricsProcessor{
 		config:          cfg,
 		cache:           cache.GetCache(set.ID.String(), cfg.CacheTtl, cfg.MetricGroups, set.Logger),

--- a/metricsasattributesprocessor/traces.go
+++ b/metricsasattributesprocessor/traces.go
@@ -2,6 +2,7 @@ package metricsasattributesprocessor
 
 import (
 	"context"
+
 	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/cache"
 	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/common"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -18,7 +19,7 @@ type tracesProcessor struct {
 	logger *zap.Logger
 }
 
-func newTracesProcessor(set processor.CreateSettings, cfg *Config) (*tracesProcessor, error) {
+func newTracesProcessor(set processor.Settings, cfg *Config) (*tracesProcessor, error) {
 	p := &tracesProcessor{
 		config: cfg,
 		cache:  cache.GetCache(set.ID.String(), cfg.CacheTtl, cfg.MetricGroups, set.Logger),

--- a/ocb.yaml
+++ b/ocb.yaml
@@ -3,32 +3,30 @@ dist:
   name: otelcol-custom
   description: Local OpenTelemetry Collector binary
   output_path: dist
-  otelcol_version: 0.99.0
+  otelcol_version: 0.111.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.99.0
-  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.99.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.99.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.99.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.111.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.111.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.111.0
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.99.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.99.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.111.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.111.0
   - gomod: github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor v0.3.0
     path: metricsasattributesprocessor
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.99.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.111.0
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.99.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.111.0


### PR DESCRIPTION
- Removed ballastextension as it's deprecated: https://pkg.go.dev/go.opentelemetry.io/collector/extension/ballastextension#section-readme
- Removed loggingexporter as its being replaced by debugexporter
https://pkg.go.dev/go.opentelemetry.io/collector/exporter/loggingexporter#section-readme
- Deprecations in the Go API Changelog
https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.103.0
https://github.com/open-telemetry/opentelemetry-collector/issues/9428

Running 
`ocb --config=ocb.yaml` is successful