### PR TITLE
use common logic for isSelectableX

### DIFF
--- a/metricsasattributesprocessor/common.go
+++ b/metricsasattributesprocessor/common.go
@@ -1,0 +1,27 @@
+package metricsasattributesprocessor
+
+import (
+	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/common"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func isSelectable(selectors []common.Selector, r pcommon.Resource, is pcommon.InstrumentationScope, attrs pcommon.Map) (string, bool) {
+	id := ""
+	for _, s := range selectors {
+		var val pcommon.Value
+		var ok bool
+		switch s.AttributeType {
+		case common.AttributeTypeResource:
+			val, ok = r.Attributes().Get(s.Name)
+		case common.AttributeTypeScope:
+			val, ok = is.Attributes().Get(s.Name)
+		default:
+			val, ok = attrs.Get(s.Name)
+		}
+		if !ok {
+			return "", false
+		}
+		id += val.AsString() + MatcherDelim
+	}
+	return id, true
+}

--- a/metricsasattributesprocessor/logs.go
+++ b/metricsasattributesprocessor/logs.go
@@ -47,7 +47,7 @@ func (lp *logsProcessor) processLogs(_ context.Context, ld plog.Logs) (plog.Logs
 func (lp *logsProcessor) addMetricsToLog(r pcommon.Resource, is pcommon.InstrumentationScope, l plog.LogRecord) {
 	for _, configMG := range lp.config.MetricGroups {
 
-		if id, ok := lp.isSelectableLog(configMG, r, is, l.Attributes()); ok {
+		if id, ok := isSelectable(configMG.TargetSelectors.LogsSelectors, r, is, l.Attributes()); ok {
 			added := 0
 			cacheMG := lp.cache.MetricGroups[configMG.Name]
 			cacheMG.Mutex.RLock()

--- a/metricsasattributesprocessor/metrics.go
+++ b/metricsasattributesprocessor/metrics.go
@@ -92,29 +92,7 @@ func (mp *metricsProcessor) isMatchedMetric(mg common.MetricGroup, name string, 
 	// if this metric does not have the necessary attributes, we can skip it
 	// an id is created by concatenating the values of the attributes selected for the metric group which will
 	// be used to identify the MatchedMetricsCache for this metric group
-	id = ""
-	for _, ms := range mg.MetricsSelectors {
-		switch ms.AttributeType {
-		case common.AttributeTypeResource:
-			if s, ok := r.Attributes().Get(ms.Name); ok {
-				id += s.AsString() + MatcherDelim
-			} else {
-				return "", "", false
-			}
-		case common.AttributeTypeScope:
-			if s, ok := is.Attributes().Get(ms.Name); ok {
-				id += s.AsString() + MatcherDelim
-			} else {
-				return "", "", false
-			}
-		case common.AttributeTypeMetric:
-			if s, ok := metricAttrs.Get(ms.Name); ok {
-				id += s.AsString() + MatcherDelim
-			} else {
-				return "", "", false
-			}
-		}
-	}
+	id, _ = isSelectable(mg.MetricsSelectors, r, is, metricAttrs)
 
 	for _, mm := range mg.MetricsMatchers {
 		if match, _ := mp.wildcardMatcher.Match(mm.InstrumentationScope, is.Name()); match {

--- a/metricsasattributesprocessor/traces.go
+++ b/metricsasattributesprocessor/traces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/cache"
-	"github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor/internal/common"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -47,7 +46,7 @@ func (tp *tracesProcessor) processTraces(_ context.Context, td ptrace.Traces) (p
 func (tp *tracesProcessor) addMetricsToSpan(r pcommon.Resource, is pcommon.InstrumentationScope, s ptrace.Span) {
 	for _, configMG := range tp.config.MetricGroups {
 
-		if id, ok := tp.isSelectableSpan(configMG, r, is, s.Attributes()); ok {
+		if id, ok := isSelectable(configMG.TargetSelectors.SpansSelectors, r, is, s.Attributes()); ok {
 			added := 0
 			cacheMG := tp.cache.MetricGroups[configMG.Name]
 			cacheMG.Mutex.RLock()
@@ -74,32 +73,4 @@ func (tp *tracesProcessor) addMetricsToSpan(r pcommon.Resource, is pcommon.Instr
 			cacheMG.Mutex.RUnlock()
 		}
 	}
-}
-
-func (tp *tracesProcessor) isSelectableSpan(mg common.MetricGroup, r pcommon.Resource, is pcommon.InstrumentationScope, spanAttrs pcommon.Map) (id string, ok bool) {
-	id = ""
-	for _, ms := range mg.TargetSelectors.SpansSelectors {
-		switch ms.AttributeType {
-		case common.AttributeTypeResource:
-			if s, ok := r.Attributes().Get(ms.Name); ok {
-				id += s.AsString() + MatcherDelim
-			} else {
-				return "", false
-			}
-		case common.AttributeTypeScope:
-			if s, ok := is.Attributes().Get(ms.Name); ok {
-				id += s.AsString() + MatcherDelim
-			} else {
-				return "", false
-			}
-		case common.AttributeTypeSpan:
-			if s, ok := spanAttrs.Get(ms.Name); ok {
-				id += s.AsString() + MatcherDelim
-			} else {
-				return "", false
-			}
-		}
-	}
-
-	return id, true
 }


### PR DESCRIPTION
Just took a spin through this repo to understand how metricsasattributesprocessor works. It seems like this simplification would be safe? Not sure it is desirable--I can appreciate keeping implementations self contained. What do you think?