### PR TITLE
Update collector to v.0.139.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 go.work
 
 dist/
+.vscode/settings.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM --platform=$BUILDPLATFORM golang:1.23-bullseye AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-bullseye AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN go install go.opentelemetry.io/collector/cmd/builder@v0.123.0
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.139.0
 
 WORKDIR /
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_REPOSITORY ?= "ghcr.io/puckpuck/opentelemetery-collector-extras/otelcol-custom"
+IMAGE_REPOSITORY ?= "ghcr.io/puckpuck/opentelemetry-collector-extras/otelcol-custom"
 IMAGE_TAG ?= "latest"
 
 .PHONY: install-builder

--- a/ocb.yaml
+++ b/ocb.yaml
@@ -5,32 +5,32 @@ dist:
   output_path: dist
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.123.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.123.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.123.0
-  #- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.123.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.139.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.139.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.139.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.139.0
+
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.123.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.123.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.139.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.139.0
   - gomod: github.com/puckpuck/opentelemetry-collector-extras/metricsasattributesprocessor v0.4.0
     path: metricsasattributesprocessor
+  - gomod: github.com/observiq/bindplane-otel-collector/processor/snapshotprocessor v1.87.3
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.123.0
-  #- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.123.0
-  #- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.123.0
-  #- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.123.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.139.0
+
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension v0.139.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades the custom collector to v0.139.0 and Go 1.24, updates component set, and adjusts build/tooling configs.
> 
> - **Collector config (`ocb.yaml`)**:
>   - Upgrade all exporters/processors/receivers/extensions to `v0.139.0`.
>   - Add `nopexporter`, `opampextension`, and `snapshotprocessor`.
>   - Remove `routingprocessor`.
> - **Build**:
>   - `Dockerfile`: move to `golang:1.24-bullseye` and `builder@v0.139.0`.
> - **Tooling**:
>   - `Makefile`: fix `IMAGE_REPOSITORY` path.
>   - `.gitignore`: add `.vscode/settings.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2027ca20d192cee35089df3edd36159c301f2a34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->